### PR TITLE
Replace copyright by CC-BY-SA; link to GitHub repo

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,4 +19,4 @@
   </ul>
 </div>
 
-<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="http://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>
+<div class="page__footer-copyright">The contents of this page, unless otherwise specified, is licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="nofollow">Creative Commons Attribution-ShareAlike 4.0 International License</a>. Hosted on <a href="https://github.com/citation-style-language/citation-style-language.github.io">GitHub Pages</a>, powered by <a href="http://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,4 +19,4 @@
   </ul>
 </div>
 
-<div class="page__footer-copyright">The contents of this page, unless otherwise specified, is licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="nofollow">Creative Commons Attribution-ShareAlike 4.0 International License</a>. Hosted on <a href="https://github.com/citation-style-language/citation-style-language.github.io">GitHub Pages</a>, powered by <a href="http://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>
+<div class="page__footer-copyright">The contents of this page, unless otherwise specified, are licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="nofollow">Creative Commons Attribution-ShareAlike 4.0 International License</a>. Hosted on <a href="https://github.com/citation-style-language/citation-style-language.github.io">GitHub Pages</a>, powered by <a href="http://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>


### PR DESCRIPTION
We’re considering becoming a member of the Software Freedom Conservancy, and they’re rather keen on avoiding any copyright statements in favor of open source licenses for any CSL-produced content.

https://sfconservancy.org/ uses “This page, and all contents herein, unless a license is otherwise specified, are licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.” in its footer, but our Minimal Mistakes theme is MIT licensed, so I limited the footer license statement to the page contents.

I also added a link to our repo. Closes #10.

See also https://github.com/citation-style-language/schema/issues/126 for a discussion of relicensing.