### PR TITLE
Redirect /styles/ to /authors/

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -179,6 +179,7 @@ timezone: # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 # Plugins
 gems:
+  - jekyll-redirect-from
   - jekyll-paginate
   - jekyll-sitemap
   - jekyll-gist
@@ -187,6 +188,7 @@ gems:
 
 # mimic GitHub Pages with --safe
 whitelist:
+  - jekyll-redirect-from
   - jekyll-paginate
   - jekyll-sitemap
   - jekyll-gist

--- a/_pages/authors.md
+++ b/_pages/authors.md
@@ -2,6 +2,7 @@
 permalink: /authors/
 title: Authors
 layout: single
+redirect_from: /styles
 ---
 {% include toc %}
 


### PR DESCRIPTION
@pmelchor, I got this to work when I build the Jekyll site locally, but I’m not a 100% I did this correct:

1) It’s not clear to me if I need to add the “jekyll-redirect-from” gem to the Gemfile as suggested at https://github.com/jekyll/jekyll-redirect-from/blob/master/README.md. (it seemed like it was already in my local bundle) 

2) That readme also says:

```
add it to your _config.yml:

plugins:
  - jekyll-redirect-from
```

but the _config.yml of minimal mistakes use a slightly different invocation (which works for me locally, so I went with this):

```
# Plugins
gems:
  - jekyll-redirect-from
```