### PR TITLE
Reduce overall font size

### DIFF
--- a/_sass/_csl.scss
+++ b/_sass/_csl.scss
@@ -1,3 +1,19 @@
+html {
+  font-size: 12px; // change to whatever
+
+  @include breakpoint($medium) {
+    font-size: 14px; // change to whatever
+  }
+
+  @include breakpoint($large) {
+    font-size: 16px; // change to whatever
+  }
+
+  @include breakpoint($x-large) {
+    font-size: 18px; // change to whatever
+  }
+}
+
 #csl-logo {
 	max-width: 150px;
 


### PR DESCRIPTION
Inspired by https://github.com/mmistakes/minimal-mistakes/issues/1219 (although the proposed solution there seems to be for a newer version of the theme than what we use right now).

Navigation headers and TOC entries are now a bit (too?) small, though.

Closes https://github.com/citation-style-language/citation-style-language.github.io/issues/25.