### PR TITLE
Touch up sponsorship icons on home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -21,11 +21,11 @@ layout: default
     {% include multicolumn_list %}
   {% endif %}
   <div id="partners">
-    <h2>The Citation Style Language is supported by:</h2>
+    <h3>The Citation Style Language project has been sponsored by</h3>
     <ul class="csl-partners">
-      <li><a href="https://www.zotero.org/"><img src="/assets/img/zotero-logo-128x128.png"><br>Zotero</a></li>
-      <li><a href="http://papersapp.com/"><img src="/assets/img/papers-logo-128x128.png"><br>Papers</a></li>
-      <li><a href="https://www.mendeley.com/"><img src="/assets/img/mendeley-logo-128x128.png"><br>Mendeley</a></li>
+      <li><a href="https://www.zotero.org/"><img src="/assets/img/zotero-logo-128x128.png" height="64px" width="64px"><br>Zotero</a></li>
+      <li><a href="http://papersapp.com/"><img src="/assets/img/papers-logo-128x128.png" height="64px" width="64px"><br>Papers</a></li>
+      <li><a href="https://www.mendeley.com/"><img src="/assets/img/mendeley-logo-128x128.png" height="64px" width="64px"><br>Mendeley</a></li>
     <ul>
   </div>
 </div>

--- a/_sass/_csl.scss
+++ b/_sass/_csl.scss
@@ -91,11 +91,6 @@ form {
 
 #partners {
 	text-align: center;
-
-	h2 {
-		width: 100%;
-		text-align: center;
-	}
 }
 
 .csl-partners {
@@ -103,6 +98,9 @@ form {
 	width: 100%;
 	text-align: center;
 	list-style-type: none;
+
+	margin-top: 0;
+	margin-bottom: 0;
 
 	li {
 		min-width: 200px;


### PR DESCRIPTION
Set icons to half size (for retina, and because 128x128 is rather big),
tweak text, reduce margins