### PR TITLE
Center page, fix sidebar width

### DIFF
--- a/_sass/_csl.scss
+++ b/_sass/_csl.scss
@@ -150,6 +150,30 @@ input[type="submit"],
 	}
 }
 
+
+// PAGE STRUCTURE AND MARGINS ///////////////////////
+
+.page {
+  @include breakpoint($large) {
+    float: none;
+    width: initial;
+    padding-right: 0;
+    max-width: 900px;
+    margin: 0 auto;
+  }
+}
+
+.sidebar__right {
+	@include breakpoint($large) {
+		float: right;
+		margin: 0 0 20px 40px;
+		width: initial;
+		position: initial;
+		padding: 0;
+		width: 320px;
+    }
+}
+
 // OTHER ////////////////////////////////////////////
 
 form {


### PR DESCRIPTION
Issue https://github.com/citation-style-language/citation-style-language.github.io/issues/25

I have adjusted the margins, centered the page and given the sidebar a fixed width for large displays.

I think this PR (together with https://github.com/citation-style-language/citation-style-language.github.io/pull/33) largely corrects the sometimes unwieldy look of Minimal Mistakes. Let me know what you think.