### PR TITLE
Remove MIT license note from Developers page

### DIFF
--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -10,8 +10,6 @@ layout: single
 
 CSL is defined by two documents: the human-readable [CSL specification](http://docs.citationstyles.org/en/1.0.1/specification.html), and the computer-readable [CSL schema](https://github.com/citation-style-language/schema/tree/v1.0.1), written in the [RELAX NG](http://relaxng.org/) compact syntax, which can be used for validation of CSL styles and locale files.
 
-_Note_: We, the authors of the CSL schema, have agreed to relicense the schema under the more permissible MIT license, although we still have [an open pull request](https://github.com/citation-style-language/schema/pull/143) to change the license text in the schema to reflect this decision.
-
 ## Code repositories
 
 We maintain several Git repositories on GitHub at [https://github.com/citation-style-language](https://github.com/citation-style-language).

--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -10,6 +10,8 @@ layout: single
 
 CSL is defined by two documents: the human-readable [CSL specification](http://docs.citationstyles.org/en/1.0.1/specification.html), and the computer-readable [CSL schema](https://github.com/citation-style-language/schema/tree/v1.0.1), written in the [RELAX NG](http://relaxng.org/) compact syntax, which can be used for validation of CSL styles and locale files.
 
+_Note_: We, the authors of the CSL schema, have agreed to relicense the schema under the more permissible MIT license, although we still have [an open pull request](https://github.com/citation-style-language/schema/pull/143) to change the license text in the schema to reflect this decision.
+
 ## Code repositories
 
 We maintain several Git repositories on GitHub at [https://github.com/citation-style-language](https://github.com/citation-style-language).

--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -10,7 +10,7 @@ layout: single
 
 CSL is defined by two documents: the human-readable [CSL specification](http://docs.citationstyles.org/en/1.0.1/specification.html), and the computer-readable [CSL schema](https://github.com/citation-style-language/schema/tree/v1.0.1), written in the [RELAX NG](http://relaxng.org/) compact syntax, which can be used for validation of CSL styles and locale files.
 
-_Note_: We, the authors of the CSL schema, have agreed to relicense the schema under the more permissible MIT license, although we still have [an open pull request](https://github.com/citation-style-language/schema/pull/143) to change the license text in the schema to reflect this decision.
+_Note_: We, the authors of the CSL schema, have agreed to relicense the schema under the more permissible MIT license, although we still have [an open issue](https://github.com/citation-style-language/schema/issues/126) to change the license text in the schema to reflect this decision.
 
 ## Code repositories
 

--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -10,7 +10,7 @@ layout: single
 
 CSL is defined by two documents: the human-readable [CSL specification](http://docs.citationstyles.org/en/1.0.1/specification.html), and the computer-readable [CSL schema](https://github.com/citation-style-language/schema/tree/v1.0.1), written in the [RELAX NG](http://relaxng.org/) compact syntax, which can be used for validation of CSL styles and locale files.
 
-_Note_: We, the authors of the CSL schema, have agreed to relicense the schema under the more permissible MIT license, although we still have [an open issue](https://github.com/citation-style-language/schema/issues/126) to change the license text in the schema to reflect this decision.
+_Note_: We, the authors of the CSL schema, have agreed to relicense the schema under the more permissible MIT license, although we still have [an open issue](https://github.com/citation-style-language/schema/issues/126) to update the license text in past schema releases to reflect this decision.
 
 ## Code repositories
 


### PR DESCRIPTION
The [Developers page](https://citationstyles.org/developers/) currently says that the schema's MIT license is currently in an open pull request, but [that pull request](https://github.com/citation-style-language/schema/pull/143) has been merged for a while. 

This PR just removes the note, I figured its continued existence might just be an oversight. Thanks!