### PR TITLE
Add Kerko to list of software tools

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -58,6 +58,8 @@ multicolumn_list:
     url: https://juris-m.github.io/
   - title: Katalog.plus!
     url: http://katalogplus.ub.uni-bielefeld.de/
+  - title: Kerko
+    url: https://github.com/whiskyechobravo/kerko
   - title: KeyLinks
     url: http://www.keylinks.org/
   - title: Logos
@@ -122,4 +124,3 @@ multicolumn_list:
 * **[Contact](/contact/)** &ndash; contact the CSL team
 
 Curious if your software tool of choice uses CSL? Many commercial and open source products do:
-


### PR DESCRIPTION
Full disclosure: I am the author of the tool.

The tool allows setting up web applications providing faceted search interfaces for bibliographies managed in Zotero. Since it relies on CSL support provided by Zotero through the Zotero API, I'll let you decide if it should be listed in addition to Zotero. 

Thanks.