### PR TITLE
docs: link to stable specs

### DIFF
--- a/_pages/authors.md
+++ b/_pages/authors.md
@@ -83,7 +83,7 @@ Our repository CSL styles that need sentence case will generally just print titl
 Title casing seems to be unique to English.
 CSL therefore automatically excludes non-English items from title casing.
 The language of an item is defined by the value of its "language" metadata field.
-For more details, see the [Non-English Items](http://docs.citationstyles.org/en/1.0.1/specification.html#non-english-items) section in the CSL specification.
+For more details, see the [Non-English Items](https://docs.citationstyles.org/en/stable/specification.html#non-english-items) section in the CSL specification.
 {% endcapture %}
 
 <div class="notice--info">
@@ -154,8 +154,8 @@ While it takes time and dedication to become a seasoned CSL expert, most users w
 
 To get started, we recommend the following CSL documentation:
 
-* The [CSL primer](http://docs.citationstyles.org/en/1.0.1/primer.html) gives an introduction into the world of CSL, and describes the basic components of CSL styles.
-* The [CSL specification](http://docs.citationstyles.org/en/1.0.1/specification.html) describes all the features of CSL in detail, and can be used as a reference.
+* The [CSL primer](https://docs.citationstyles.org/en/stable/primer.html) gives an introduction into the world of CSL, and describes the basic components of CSL styles.
+* The [CSL specification](https://docs.citationstyles.org/en/stable/specification.html) describes all the features of CSL in detail, and can be used as a reference.
 * Zotero has a [step-by-step guide](http://www.zotero.org/support/dev/citation_styles/style_editing_step-by-step) for editing CSL styles.
   While this guide assumes you're using Zotero, it's concise and describes some concrete examples of how to edit existing styles.
 * CSL is an XML-based language, so you might want to read one of the many XML tutorials on the web to better understand the general structure of XML files like our CSL styles.

--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -8,7 +8,7 @@ layout: single
 
 ## Language Specification
 
-CSL is defined by two documents: the human-readable [CSL specification](https://docs.citationstyles.org/en/stable/specification.html), and the computer-readable [CSL schema](https://github.com/citation-style-language/schema/tree/v1.0.2), written in the [RELAX NG](http://relaxng.org/) compact syntax, which can be used for validation of CSL styles and locale files.
+CSL is defined by two documents: the human-readable [CSL specification](https://docs.citationstyles.org/en/stable/specification.html), and the computer-readable [CSL schema](https://github.com/citation-style-language/schema/releases/latest), written in the [RELAX NG](http://relaxng.org/) compact syntax, which can be used for validation of CSL styles and locale files.
 
 _Note_: We, the authors of the CSL schema, have agreed to relicense the schema under the more permissible MIT license, although we still have [an open issue](https://github.com/citation-style-language/schema/issues/126) to update the license text in past schema releases to reflect this decision.
 

--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -8,7 +8,7 @@ layout: single
 
 ## Language Specification
 
-CSL is defined by two documents: the human-readable [CSL specification](http://docs.citationstyles.org/en/1.0.1/specification.html), and the computer-readable [CSL schema](https://github.com/citation-style-language/schema/tree/v1.0.1), written in the [RELAX NG](http://relaxng.org/) compact syntax, which can be used for validation of CSL styles and locale files.
+CSL is defined by two documents: the human-readable [CSL specification](https://docs.citationstyles.org/en/stable/specification.html), and the computer-readable [CSL schema](https://github.com/citation-style-language/schema/tree/v1.0.2), written in the [RELAX NG](http://relaxng.org/) compact syntax, which can be used for validation of CSL styles and locale files.
 
 _Note_: We, the authors of the CSL schema, have agreed to relicense the schema under the more permissible MIT license, although we still have [an open issue](https://github.com/citation-style-language/schema/issues/126) to update the license text in past schema releases to reflect this decision.
 

--- a/_pages/ontology.md
+++ b/_pages/ontology.md
@@ -86,11 +86,11 @@ redirect_from:
   - /ontology/type/webpage
 ---
 
-The [CSL specification](https://docs.citationstyles.org/en/1.0.1/specification.html) implies a data model with:
+The [CSL specification](https://docs.citationstyles.org/en/stable/specification.html) implies a data model with:
 
-* [categories](https://docs.citationstyles.org/en/1.0.1/specification.html#appendix-i-categories) to indicate academic fields such as `astronomy` and `biology`,
-* [contributor roles](https://docs.citationstyles.org/en/1.0.1/specification.html#roles) such as `author` and `translator`,
-* [publication types](https://docs.citationstyles.org/en/1.0.1/specification.html#appendix-iii-types) such as `article` and `book`.
+* [categories](https://docs.citationstyles.org/en/stable/specification.html#appendix-i-categories) to indicate academic fields such as `astronomy` and `biology`,
+* [contributor roles](https://docs.citationstyles.org/en/stable/specification.html#name-variables) such as `author` and `translator`,
+* [publication types](https://docs.citationstyles.org/en/stable/specification.html#appendix-iii-types) such as `article` and `book`.
 
 To support referencing these CSL concepts, each is given a globally unique [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) with prefix
 

--- a/_pages/redirects/primer.md
+++ b/_pages/redirects/primer.md
@@ -3,7 +3,7 @@ permalink: /downloads/primer.html
 title: Redirect Page
 layout: single
 redirect_to:
-  - http://docs.citationstyles.org/en/1.0.1/primer.html
+  - https://docs.citationstyles.org/en/stable/primer.html
 ---
 
 Redirecting...

--- a/_pages/redirects/specification-csl101.md
+++ b/_pages/redirects/specification-csl101.md
@@ -3,7 +3,7 @@ permalink: /downloads/specification-csl101-20120903.html
 title: Redirect Page
 layout: single
 redirect_to:
-  - http://docs.citationstyles.org/en/1.0.1/specification.html
+  - https://docs.citationstyles.org/en/stable/specification.html
 ---
 
 Redirecting...

--- a/_pages/redirects/specification.md
+++ b/_pages/redirects/specification.md
@@ -3,7 +3,7 @@ permalink: /downloads/specification.html
 title: Redirect Page
 layout: single
 redirect_to:
-  - http://docs.citationstyles.org/en/1.0.1/specification.html
+  - https://docs.citationstyles.org/en/stable/specification.html
 ---
 
 Redirecting...


### PR DESCRIPTION
Replace hardcoded links to 1.0.1 specs to latest specs.

Notes:

1. I couldn't find the equivalent of 1.0.2/latest of https://docs.citationstyles.org/en/1.0.1/release-notes.html
2. I couldn't find a "latest" link to schemas. I resorted to hardcoding a 1.0.2 link instead.