### PR TITLE
Update developers.md

### DIFF
--- a/_pages/developers.md
+++ b/_pages/developers.md
@@ -68,7 +68,7 @@ Open source CSL 1.0.2-compatible CSL processors include:
       <td>Java</td>
       <td>Michel Krämer</td>
       <td></td>
-      <td>Java wrapper for citeproc-js</td>
+      <td></td>
     </tr>
     <tr>
       <td><a href="https://github.com/juris-m/citeproc-js">citeproc‑js</a></td>


### PR DESCRIPTION
Citeproc-java has been completely rewritten in java so this comment is obsolete. See: https://michelkraemer.com/generate-citations-and-bibliographies-faster-with-citeproc-java-3.0.0/