### PR TITLE
Mention Typst as CSL user

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -120,6 +120,8 @@ multicolumn_list:
     url: https://talis.com/talis-aspire/
   - title: Texture
     url: https://github.com/substance/texture
+  - title: Typst
+    url: https://typst.app/
   - title: WordPress
     children:
       - title: Academic Blogger’s Toolkit


### PR DESCRIPTION
Typst uses the CSL for formatting the bibliography and citations, see [Typst documentation](https://typst.app/docs/reference/model/bibliography/#parameters-style).

Original discussion in Typst repository: https://github.com/typst/citationberg/issues/31